### PR TITLE
Update Helping Out Page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 cache/
+__pycache__/
+*.bak
 conf.pyc
-.doit.db
+*.doit.db.*
 output/

--- a/pages/helping-out.md
+++ b/pages/helping-out.md
@@ -9,4 +9,39 @@
 .. type: text
 -->
 
-TODO: page about how to join the IRC channel, or who to contact to donate to the meetup fund.
+Thank you for your interest! This page will try to cover a few topics, including how to join our IRC channel, and who to contact with any questions. We'll also go over the basic steps to contribute to our meetup fund.
+
+## IRC ##
+----------
+
+Internet Relay Chat (IRC) is a real-time text based chat protocol. Based on a server client architecture, think of IRC as  chat rooms. There are many different IRC servers, such as [Freenode](https://freenode.net/) and [Rizon](https://www.rizon.net/). Each server may contain hundreds of channels, which is where you'll do all your talking. New Guard utilizes the Freenode network for our chat needs.
+
+Server: **irc.freenode.net**
+Channel: **#newguard**
+
+To get started with IRC, you'll need an IRC client. A great open source client is [HexChat](https://hexchat.github.io/downloads.html). You can build from [source](https://github.com/hexchat), or install a [package](https://hexchat.github.io/downloads.html) in Windows, Linux, or OS X. For the purpose of this guide, we are going to use HexChat and [raw commands](http://www.irchelp.org/irchelp/irctutorial.html), but no matter what client you use, the commands should work.
+
+First things first, you are going to need to start up your IRC client of choice and join the Freenode network by using the /SERVER command. Just type this into your client and press enter:
+
+    /server irc.freenode.com
+
+You are probably going to see a bunch of text appear, but don't panic! If all goes well, you should see something along the lines "end of /MOTD command." If you are using HexChat, you may also see a popup that says "Connection Complete." You can close this by clicking the X on the popup or selecting the first radio button and clicking OK.
+
+Now is a good time to set your nickname, or nick for short. The command for that is extremely simple:
+
+    /nick FoobarSmith
+
+Everyone will see you by your nick, so try to pick something unique and easy to remember and type. With any luck, your nickname isn't taken ("Nickname is already in use.") If it is, just set a new one.
+
+Now the moment you have been waiting for, joining our channel and getting involved. This is another easy command:
+
+    /join #newguard
+
+Really, it is as easy as that! You should be in our channel - try to type a hello message and press enter. Depending on the time and day, you may see no chatter, or a whole bunch of it. Please hang around a bit! Even though there may be a bunch of people on the channel, not everyone is always paying attention or awake, but eventually, someone will begin to talk.
+
+You are highly encouraged to read [this comprehensive IRC tutorial and command list](http://www.irchelp.org/irchelp/irctutorial.html), and do research into the IRC protocol. Knowledge is power!
+
+## Funding and Contacting Us ##
+----------
+
+New Guard is an [Internet Civil Engineer Institute](http://icei.org) (ICEI) initiative. We rely on your funding to teach today's youth about infrastructure. We are working towards face-to-face meetups, where less-experienced members can interact with senior architects to further their education. Susan Sons (aka Hedgemage) is responsible for all donations. We urge you to contact her at [donations@icei.org](mailto:donations@icei.org) for more information. Any little bit will help us achieve our goal.

--- a/pages/helping-out.md
+++ b/pages/helping-out.md
@@ -44,4 +44,4 @@ You are highly encouraged to read [this comprehensive IRC tutorial and command l
 ## Funding and Contacting Us ##
 ----------
 
-New Guard is an [Internet Civil Engineer Institute](http://icei.org) (ICEI) initiative. We rely on your funding to teach today's youth about infrastructure. We are working towards face-to-face meetups, where less-experienced members can interact with senior architects to further their education. Susan Sons (aka Hedgemage) is responsible for all donations. We urge you to contact her at [donations@icei.org](mailto:donations@icei.org) for more information. Any little bit will help us achieve our goal.
+New Guard is an [Internet Civil Engineering Institute](http://icei.org) (ICEI) initiative. We rely on your funding to teach today's youth about infrastructure. We are working towards face-to-face meetups, where less-experienced members can interact with senior architects to further their education. Susan Sons (aka Hedgemage) is responsible for all donations. We urge you to contact her at [donations@icei.org](mailto:donations@icei.org) for more information. Any little bit will help us achieve our goal.


### PR DESCRIPTION
Included basic instructions on how to join our IRC channel on the Freenode network, and who to contact with questions/more information on funding.

Additionally, updated .gitignore to ignore a wider range of temporary files.

Please review and give feedback on the helping out page, any suggestions on how to clarify the instructions would be appreciated.